### PR TITLE
Fix network table

### DIFF
--- a/manuscript/reference/networks.md
+++ b/manuscript/reference/networks.md
@@ -5,8 +5,7 @@ In order to avoid IP addressing conflicts as we bring swarm networks up/down, we
 Network  | Range
 --|--
 [Traefik](https://geek-cookbook.funkypenguin.co.nz/ha-docker-swarm/traefik/)  | _unspecified_
-[Docker-cleanup](https://geek-cookbook.funkypenguin.co.nz/ha-docker-swarm/docker-swarm-mode/#setup-automated-cleanup) |
-172.16.0.0/24
+[Docker-cleanup](https://geek-cookbook.funkypenguin.co.nz/ha-docker-swarm/docker-swarm-mode/#setup-automated-cleanup) | 172.16.0.0/24
 [Mail Server](https://geek-cookbook.funkypenguin.co.nz/recipies/mail/)  | 172.16.1.0/24
 [Gitlab](https://geek-cookbook.funkypenguin.co.nz/recipies/gitlab/) | 172.16.2.0/24
 [Wekan](https://geek-cookbook.funkypenguin.co.nz/recipies/wekan/)  |  172.16.3.0/24


### PR DESCRIPTION
Noticed while following your guides that the table put the network for docker-cleanup in it's own row rather than in the column next to Docker-cleanup