### PR TITLE
Bye zappi, hello a5huynh

### DIFF
--- a/manuscript/recipies/autopirate/headphones.md
+++ b/manuscript/recipies/autopirate/headphones.md
@@ -24,7 +24,7 @@ headphones:
   - internal
 
 headphones_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/headphones.env 
   networks:
     - internal

--- a/manuscript/recipies/autopirate/jackett.md
+++ b/manuscript/recipies/autopirate/jackett.md
@@ -23,7 +23,7 @@ jackett:
   - internal
 
 jackett_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/jackett.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/lazylibrarian.md
+++ b/manuscript/recipies/autopirate/lazylibrarian.md
@@ -28,7 +28,7 @@ lazylibrarian:
   - internal
 
 lazylibrarian_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/lazylibrarian.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/mylar.md
+++ b/manuscript/recipies/autopirate/mylar.md
@@ -22,7 +22,7 @@ mylar:
   - internal
 
 mylar_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/mylar.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/nzbget.md
+++ b/manuscript/recipies/autopirate/nzbget.md
@@ -28,7 +28,7 @@ nzbget:
   - internal
 
 nzbget_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/nzbget.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/nzbhydra.md
+++ b/manuscript/recipies/autopirate/nzbhydra.md
@@ -28,7 +28,7 @@ nzbhydra:
   - internal
 
 nzbhydra_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/nzbhydra.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/nzbhydra2.md
+++ b/manuscript/recipies/autopirate/nzbhydra2.md
@@ -43,7 +43,7 @@ nzbhydra2:
   - internal
 
 nzbhydra2_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/nzbhydra2.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/ombi.md
+++ b/manuscript/recipies/autopirate/ombi.md
@@ -29,7 +29,7 @@ ombi:
   - internal
 
 ombi_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/ombi.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/radarr.md
+++ b/manuscript/recipies/autopirate/radarr.md
@@ -40,7 +40,7 @@ radarr:
   - internal
 
 radarr_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/radarr.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/sabnzbd.md
+++ b/manuscript/recipies/autopirate/sabnzbd.md
@@ -31,7 +31,7 @@ sabnzbd:
   - internal
 
 sabnzbd_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/sabnzbd.env
   networks:
     - internal

--- a/manuscript/recipies/autopirate/sonarr.md
+++ b/manuscript/recipies/autopirate/sonarr.md
@@ -26,7 +26,7 @@ sonarr:
   - internal
 
 sonarr_proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/config/autopirate/sonarr.env
   networks:
     - internal

--- a/manuscript/recipies/calibre-web.md
+++ b/manuscript/recipies/calibre-web.md
@@ -77,7 +77,7 @@ services:
     - internal
 
   proxy:
-    image: zappi/oauth2_proxy
+    image: a5huynh/oauth2_proxy
     env_file : /var/data/config/calibre-web/calibre-web.env
     dns_search: hq.example.com
     networks:

--- a/manuscript/recipies/gollum.md
+++ b/manuscript/recipies/gollum.md
@@ -81,7 +81,7 @@ services:
       --user-icons gravatar
 
   proxy:
-    image: zappi/oauth2_proxy
+    image: a5huynh/oauth2_proxy
     env_file : /var/data/config/gollum/gollum.env
     networks:
       - internal

--- a/manuscript/recipies/homeassistant.md
+++ b/manuscript/recipies/homeassistant.md
@@ -85,7 +85,7 @@ services:
         - internal
 
     grafana-proxy:
-      image: zappi/oauth2_proxy
+      image: a5huynh/oauth2_proxy
       env_file : /var/data/config/homeassistant/grafana.env
       dns_search: hq.example.com
       networks:

--- a/manuscript/recipies/kanboard.md
+++ b/manuscript/recipies/kanboard.md
@@ -76,7 +76,7 @@ services:
         - traefik.port=80
 
     proxy:
-      image: zappi/oauth2_proxy
+      image: a5huynh/oauth2_proxy
       env_file : /var/data/config/kanboard/kanboard.env
       networks:
         - internal

--- a/manuscript/recipies/munin.md
+++ b/manuscript/recipies/munin.md
@@ -74,7 +74,7 @@ services:
       - /var/data/munin/cache:/var/cache/munin  
 
   proxy:
-    image: zappi/oauth2_proxy
+    image: a5huynh/oauth2_proxy
     env_file: /var/data/config/munin/munin.env
     networks:
       - traefik

--- a/manuscript/recipies/owntracks.md
+++ b/manuscript/recipies/owntracks.md
@@ -65,7 +65,7 @@ services:
         - 8083:8083
 
     owntracks-proxy:
-      image: zappi/oauth2_proxy
+      image: a5huynh/oauth2_proxy
       env_file : /var/data/config/owntracks/owntracks.env
       networks:
         - internal

--- a/manuscript/recipies/template.md
+++ b/manuscript/recipies/template.md
@@ -62,7 +62,7 @@ services:
       - /var/data/wekan/wekan-db-dump:/dump
 
   proxy:
-    image: zappi/oauth2_proxy
+    image: a5huynh/oauth2_proxy
     env_file: /var/data/wekan/wekan.env
     networks:
       - traefik

--- a/manuscript/recipies/wallabag.md
+++ b/manuscript/recipies/wallabag.md
@@ -93,7 +93,7 @@ services:
       - /var/data/wallabag/images:/var/www/wallabag/web/assets/images
 
   wallabag_proxy:
-   image: zappi/oauth2_proxy
+   image: a5huynh/oauth2_proxy
    env_file: /var/data/config/wallabag/wallabag.env
    networks:
      - internal

--- a/manuscript/recipies/wekan.md
+++ b/manuscript/recipies/wekan.md
@@ -70,7 +70,7 @@ services:
       - /var/data/wekan/database-dump:/dump
 
   proxy:
-    image: zappi/oauth2_proxy
+    image: a5huynh/oauth2_proxy
     env_file: /var/data/config/wekan/wekan.env
     networks:
       - traefik

--- a/manuscript/reference/oauth_proxy.md
+++ b/manuscript/reference/oauth_proxy.md
@@ -51,7 +51,7 @@ You'll need to define a service for the oauth_proxy in every stack which you wan
 
 ```
 proxy:
-  image: zappi/oauth2_proxy
+  image: a5huynh/oauth2_proxy
   env_file : /var/data/wekan/wekan.env
   networks:
     - traefik


### PR DESCRIPTION
Several subscribers have been having issues with zappi/oauth2_proxy, so wholesale-replaced with a5huynh/oauth2_proxy