### PR TITLE
Add missing [ for link to KeyCloak

### DIFF
--- a/manuscript/recipes/openldap.md
+++ b/manuscript/recipes/openldap.md
@@ -439,4 +439,4 @@ Create your users using the "**New User**" button.
 
 ## Chef's Notes 📓
 
-1. The KeyCloak](/recipes/keycloak/authenticate-against-openldap/) recipe illustrates how to integrate KeyCloak with your LDAP directory, giving you a cleaner interface to manage users, and a raft of SSO / OAuth features.
+1. [The KeyCloak](/recipes/keycloak/authenticate-against-openldap/) recipe illustrates how to integrate KeyCloak with your LDAP directory, giving you a cleaner interface to manage users, and a raft of SSO / OAuth features.


### PR DESCRIPTION
Noticed that there was a missing [ for linking, so here it is