### PR TITLE
Correct image for traefik-forward-auth

### DIFF
--- a/manuscript/ha-docker-swarm/traefik-forward-auth/keycloak.md
+++ b/manuscript/ha-docker-swarm/traefik-forward-auth/keycloak.md
@@ -52,7 +52,7 @@ This is a small container, you can simply add the following content to the exist
 
 ```
   traefik-forward-auth:
-    image: thomseddon/traefik-forward-auth
+    image: funkypenguin/traefik-forward-auth
     env_file: /var/data/config/traefik/traefik-forward-auth.env
     networks:
       - traefik_public


### PR DESCRIPTION
thomseddon/traefik-forward-auth does not support the OIDC_ISSUER parameter, but the one maintained by funkypenguin does.