### PR TITLE
Fixed Broken Links

### DIFF
--- a/manuscript/recipes/autopirate.md
+++ b/manuscript/recipes/autopirate.md
@@ -111,8 +111,8 @@ networks:
 
 Now work your way through the list of tools below, adding whichever tools your want to use, and finishing with the **end** section:
 
-* [SABnzbd](/recipes/autopirate/sabnzbd.md)
-* [NZBGet](/recipes/autopirate/nzbget.md)
+* [SABnzbd](/recipes/autopirate/sabnzbd/)
+* [NZBGet](/recipes/autopirate/nzbget/)
 * [RTorrent](/recipes/autopirate/rtorrent/)
 * [Sonarr](/recipes/autopirate/sonarr/)
 * [Radarr](/recipes/autopirate/radarr/)


### PR DESCRIPTION
Some links point to a .md file, causing the formatting to not be loaded, and a 404 error displayed (https://geek-cookbook.funkypenguin.co.nz/recipes/autopirate/sabnzbd.md) 
Fix by pointing to a directory and not the file.