### PR TITLE
Fix cookie_domain env

### DIFF
--- a/manuscript/ha-docker-swarm/traefik-forward-auth/keycloak.md
+++ b/manuscript/ha-docker-swarm/traefik-forward-auth/keycloak.md
@@ -43,7 +43,7 @@ CLIENT_SECRET=<your keycloak client secret>
 OIDC_ISSUER=https://<your keycloak URL>/auth/realms/master
 SECRET=<a random string to secure your cookie>
 AUTH_HOST=<the FQDN to use for your auth host>
-COOKIE_DOMAINS=<the root FQDN of your domain>
+COOKIE_DOMAIN=<the root FQDN of your domain>
 ```
 
 ### Prepare the docker service config


### PR DESCRIPTION
According to https://github.com/SuperSandro2000/traefik-forward-auth#configuration and my personal testing this needs to be without the S.