### PR TITLE
Fix: Changed sqlite3 db location

### DIFF
--- a/docs/docker-swarm/traefik-forward-auth/dex-static.md
+++ b/docs/docker-swarm/traefik-forward-auth/dex-static.md
@@ -24,7 +24,7 @@ issuer: https://dex.example.com
 storage:
   type: sqlite3
   config:
-    file: var/sqlite/dex.db
+    file: var/dex/dex.db
 
 web:
   http: 0.0.0.0:5556


### PR DESCRIPTION
## Description
The `var/sqlite/dex.db` location for sqlite3 wasn't working for me. Always the same Database migration error so i decided to thoroughly read the official docs and just made this one change to use the default db location `var/dex/dex.db` instead and it works
I still can't explain it why. Maybe you could

## How Has This Been Tested?
Just Set this up on my personal Home Stack