### PR TITLE
disable traefik when deploy other master nodes

### DIFF
--- a/docs/kubernetes/cluster/k3s.md
+++ b/docs/kubernetes/cluster/k3s.md
@@ -111,7 +111,7 @@ Now that the first master is deploy, add additional masters (*remember to keep t
 ```bash
 MYSECRET=iambatman
 curl -fL https://get.k3s.io | K3S_TOKEN=${MYSECRET} \
-    sh -s - server --disable servicelb --server https://<IP OF FIRST MASTER>:6443
+    sh -s - server --disable traefik --disable servicelb --server https://<IP OF FIRST MASTER>:6443
 ```
 
 Run `k3s kubectl get nodes` to see your new master node make friends with the others:


### PR DESCRIPTION
Without using `--disable traefik` when deploying other master nodes, the default traefik get installed, even if removed from the original master node.

<!-- Provide a general summary of your changes in the Title above ^^^ -->

## Description
<!--- Describe your changes in detail -->

Existing doc fix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I created secondary master node and now I have to figure out a way to remove traefik from them!

I had to run the following to remove the included traefik:

```shell
curl -sfL https://get.k3s.io | K3S_TOKEN=${TOKEN} sh -s - server --disable=traefik,servicelb --server https://${MMIP}:6443
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Existing doc fix.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- ignore-task-list-start -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [ ] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.

