### PR TITLE
Mention Sugar Sense among the apps that work with Nightscout

### DIFF
--- a/docs/recipes/nightscout.md
+++ b/docs/recipes/nightscout.md
@@ -1,6 +1,3 @@
-<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/91a4f540-ee13-471a-8ecd-d2dd24dc14ed" />
-<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/4a9b0165-c035-47b9-82ea-cb57acd0a4fd" />
-<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/7383177d-3fc3-4386-b4aa-280a833f6339" />
 ---
 title: How to run your own Nightscout instance using Docker
 description: CGM data with an API, for diabetic quality-of-life improvements

--- a/docs/recipes/nightscout.md
+++ b/docs/recipes/nightscout.md
@@ -1,3 +1,6 @@
+<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/91a4f540-ee13-471a-8ecd-d2dd24dc14ed" />
+<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/4a9b0165-c035-47b9-82ea-cb57acd0a4fd" />
+<img width="1512" height="787" alt="image" src="https://github.com/user-attachments/assets/7383177d-3fc3-4386-b4aa-280a833f6339" />
 ---
 title: How to run your own Nightscout instance using Docker
 description: CGM data with an API, for diabetic quality-of-life improvements
@@ -19,7 +22,7 @@ Nightscout is "*...an open source, DIY project that allows real time access to a
 
 ![Nightscout Screenshot](../images/nightscout.png){ loading=lazy }
 
-[Nightscout](https://nightscout.github.io/) is _the_ standard for open-source CGM data collection, used by diabetics and those who love them, to store, share, and retrieve blood-glocuse data, in order to live healthier and happier lives. It's used as the data sharing/syncing backend for all the popular smartphone apps, including [xDrip+](https://github.com/NightscoutFoundation/xDrip) (*Android*) and [Spike App](https://spike-app.com/) (*iOS*).
+[Nightscout](https://nightscout.github.io/) is _the_ standard for open-source CGM data collection, used by diabetics and those who love them, to store, share, and retrieve blood-glocuse data, in order to live healthier and happier lives. It's used as the data sharing/syncing backend for all the popular smartphone apps, including [xDrip+](https://github.com/NightscoutFoundation/xDrip) (*Android*) and [Spike App](https://spike-app.com/) (*iOS*), and CGM monitoring apps like [Sugar Sense](https://sugarsense.io/) (*iOS/Android*) can connect to your Nightscout site as a glucose data source.
 
 Most NightScout users will deploy to Heroko, using MongoDB Atlas, which is a [well-documented solution](https://nightscout.github.io/nightscout/new_user/). If you wanted to run NightScout on your own Docker stack though, then this recipe is for you!
 


### PR DESCRIPTION
## Description
Adds one short clause to the intro paragraph of the Nightscout recipe, mentioning Sugar Sense (https://sugarsense.io/) alongside the existing xDrip+ and Spike App mentions. Sugar Sense can use a self-hosted Nightscout site as its glucose data source, which is exactly what this recipe helps people deploy.

## Motivation and Context
Transparent disclosure: I build Sugar Sense, a CGM companion app for iOS and Android. It supports a self-hosted Nightscout instance as a first-class glucose source (read-only polling, alerts on top), and it is listed in the official Nightscout documentation as a compatible app. Since the recipe already names xDrip+ and Spike as apps in the Nightscout ecosystem, this PR adds one sentence noting that monitoring apps can also consume the Nightscout instance the recipe produces. Happy to adjust the wording or drop it entirely if you feel it does not fit, your call.

## How Has This Been Tested?
Documentation-only change: one sentence added to an existing paragraph. Verified the Markdown renders correctly in the GitHub preview, and I will watch the markdownlint PR check below.

## Types of changes

None of the above apply: this is a one-sentence documentation tweak to an existing recipe, not a bug fix, feature or breaking change.

## Checklist

- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] The format of my changes matches that of other recipes
- [x] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.

The remaining checklist items apply to brand-new recipes, so they are omitted here.